### PR TITLE
Update remaining items from products to events for order completion

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -13,7 +13,7 @@ class Order < ActiveRecord::Base
   scope :completed, -> { where(status: 3) }
 
   def total
-    order_items.reduce(0) do |total, order_item|
+    event_orders.reduce(0) do |total, order_item|
       total + (order_item.quantity * order_item.unit_price)
     end
   end

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -54,7 +54,7 @@
       </div>
     <% end %>
   </div>
-  <%= link_to "Continue Shopping", products_path,
+  <%= link_to "Continue Shopping", root_path,
               class: "btn btn-lg btn-primary pull-left" %>
   <%= link_to "Dashboard", dashboard_path,
               class: "btn btn-lg btn-success pull-right" %>

--- a/app/views/partials/_single_order_table.html.erb
+++ b/app/views/partials/_single_order_table.html.erb
@@ -9,17 +9,18 @@
     </tr>
   </thead>
   <tbody>
-    <% @order.order_items.each do |order_item| %>
+    <% @order.event_orders.each do |event_order_item| %>
       <tr>
         <td>
-          <a href="<%= product_path(order_item.product) %>">
-            <%= order_item.product.name %>
+          <a href="<%= vendor_event_path(vendor: event_order_item.event.user.url,
+                                         id: event_order_item.event_id) %>">
+            <%= event_order_item.event.name %>
           </a>
         </td>
         <td><%= @order.status %></td>
-        <td><%= order_item.quantity %></td>
-        <td><%= number_to_currency(order_item.unit_price) %></td>
-        <td><%= number_to_currency(order_item.subtotal) %></td>
+        <td><%= event_order_item.quantity %></td>
+        <td><%= number_to_currency(event_order_item.unit_price) %></td>
+        <td><%= number_to_currency(event_order_item.subtotal) %></td>
       </tr>
     <% end %>
     <tr>


### PR DESCRIPTION
Must set Stripe and Twilio API keys locally, but otherwise you are now able to add events to the cart and fully complete the checkout process.
